### PR TITLE
 Performance: Optimize main loop, chunk cleanup, and rendering hot paths

### DIFF
--- a/src/chunk.py
+++ b/src/chunk.py
@@ -126,6 +126,15 @@ def generate_chunk(chunk_x, chunk_y, texture_atlas, atlas_items, space):
 # Store generated chunks
 chunks = {}
 
+def _remove_block_from_space(block, space):
+    if block is None or space is None:
+        return
+    try:
+        if block.body in space.bodies or block.shape in space.shapes:
+            space.remove(block.body, block.shape)
+    except Exception:
+        pass
+
 def get_block(chunk_x, chunk_y, x, y, texture_atlas, atlas_items, space):
     if chunk_y < 0:
         return None
@@ -138,13 +147,20 @@ def get_block(chunk_x, chunk_y, x, y, texture_atlas, atlas_items, space):
             
     return chunks[(chunk_x, chunk_y)][y][x]
 
-def delete_block(chunk_x, chunk_y, x, y):
+def delete_block(chunk_x, chunk_y, x, y, space=None):
     if (chunk_x, chunk_y) in chunks:
-        chunks[(chunk_x, chunk_y)][y][x].hp = 0
+        block = chunks[(chunk_x, chunk_y)][y][x]
+        if block is not None:
+            block.hp = 0
+            _remove_block_from_space(block, space)
         del chunks[(chunk_x, chunk_y)][y][x]
         chunks[(chunk_x, chunk_y)][y][x] = None
 
-def clean_chunks(start_chunk_y):
+def clean_chunks(start_chunk_y, space):
     for (chunk_x, chunk_y) in list(chunks.keys()):
         if chunk_y < start_chunk_y:
+            chunk = chunks[(chunk_x, chunk_y)]
+            for row in chunk:
+                for block in row:
+                    _remove_block_from_space(block, space)
             del chunks[(chunk_x, chunk_y)]

--- a/src/explosion.py
+++ b/src/explosion.py
@@ -1,9 +1,6 @@
 import pygame
 import random
 
-import pygame
-import random
-
 class ExplosionParticle:
     def __init__(self, pos, texture_atlas, atlas_items, frame_count=16, frame_duration=1):
         """
@@ -26,13 +23,20 @@ class ExplosionParticle:
 
         # Random rotation between 0 and 360 degrees.
         self.rotation = random.uniform(0, 360)
+        self.frames = []
+        for i in range(self.frame_count):
+            key = f"explosion_{i}"
+            rect = pygame.Rect(self.atlas_items["particle"][key])
+            texture = self.texture_atlas.subsurface(rect)
+            texture = pygame.transform.rotate(texture, self.rotation)
+            self.frames.append(texture)
 
-    def update(self, dt):
+    def update(self, dt_ms):
         """Update animation frame based on elapsed time or frame count."""
         if self.finished:
             return
 
-        self.elapsed_time += dt * 1000
+        self.elapsed_time += dt_ms
         if self.elapsed_time >= self.frame_duration:
             self.elapsed_time -= self.frame_duration
             self.current_frame += 1
@@ -46,20 +50,10 @@ class ExplosionParticle:
         if self.finished:
             return
         
-        # Get the corresponding rect for the current explosion frame
-        key = f"explosion_{self.current_frame}"
-        # Ensure the atlas_items[key] is a tuple or pygame.Rect
-        rect = pygame.Rect(self.atlas_items["particle"][key])
-        texture = self.texture_atlas.subsurface(rect)
-
-        # Rotate the texture
-        texture = pygame.transform.rotate(texture, self.rotation)
-
-        # Scale texture to the desired size
         # Adjust drawing position by camera offset (if only vertical, subtract camera.offset_y)
         draw_pos = (self.pos.x - camera.offset_x, self.pos.y - camera.offset_y)
 
-        screen.blit(texture, draw_pos)
+        screen.blit(self.frames[self.current_frame], draw_pos)
 
 class Explosion:
     def __init__(self, pos, texture_atlas, atlas_items, particle_count=20):
@@ -77,12 +71,9 @@ class Explosion:
             particle = ExplosionParticle(pos + offset, texture_atlas, atlas_items)
             self.particles.append(particle)
 
-    def update(self):
-        # get time from last frame
-        dt = pygame.time.get_ticks()
-
+    def update(self, dt_ms):
         for particle in self.particles:
-            particle.update(dt)
+            particle.update(dt_ms)
 
         # Optionally remove finished particles
         self.particles = [p for p in self.particles if not p.finished]

--- a/src/pickaxe.py
+++ b/src/pickaxe.py
@@ -150,8 +150,10 @@ class Pickaxe:
         elif(name =="netherite_pickaxe"):
             self.damage = 12
 
-    def update(self):
+    def update(self, current_time=None):
         """Apply gravity, update movement, check collisions, and rotate."""
+        if current_time is None:
+            current_time = pygame.time.get_ticks()
         # Manually limit the falling speed (terminal velocity)
         if self.body.velocity.y > 1000:
             self.body.velocity = (self.body.velocity.x, 1000)
@@ -182,7 +184,7 @@ class Pickaxe:
             self.body.position = (self.body.position.x - dx, self.body.position.y)
 
         # If pickaxe is enlarged, check if time is up
-        if hasattr(self, "enlarge_end_time") and pygame.time.get_ticks() > self.enlarge_end_time:
+        if hasattr(self, "enlarge_end_time") and current_time > self.enlarge_end_time:
             self.reset_size()
             self.is_enlarged = False
 

--- a/src/youtube.py
+++ b/src/youtube.py
@@ -113,6 +113,7 @@ def get_new_live_chat_messages(live_chat_id):
     log_file = log_dir / f"chat_{datetime.today().strftime('%Y-%m-%d')}.txt"
 
     messages = []
+    log_lines = []
     for item in response["items"]:
         message_id = item["id"]  # Unique message ID
         if message_id not in seen_messages:
@@ -135,9 +136,7 @@ def get_new_live_chat_messages(live_chat_id):
             else:
                 log_message = f"[{timestamp}] {author}: {message}"
 
-            # Write to file
-            with open(log_file, "a+", encoding="utf-8") as chat_file:
-                chat_file.write(log_message + "\n")
+            log_lines.append(log_message)
 
             messages.append({
                 "timestamp": timestamp,
@@ -146,6 +145,10 @@ def get_new_live_chat_messages(live_chat_id):
                 "sc_details": item["snippet"].get("superChatDetails", None),
                 "ss_details": item["snippet"].get("superStickerDetails", None)
             })
+
+    if log_lines:
+        with open(log_file, "a+", encoding="utf-8") as chat_file:
+            chat_file.write("\n".join(log_lines) + "\n")
 
     return messages
 


### PR DESCRIPTION
### Motivation
- Reduce per-frame overhead in the main loop (rendering, input processing, and timed events) to improve FPS stability.
- Prevent long-session slowdowns by properly removing chunk bodies/shapes from the Pymunk Space.
- Reduce expensive full-world scans during TNT explosions and avoid repeated allocations in HUD/particles/logging.

### Description
- Replaced list-based chat queues with collections.deque and per-queue author sets to avoid O(n) pop(0) and repeated linear duplicate checks.
- Threaded current_time / dt_ms through updates to avoid repeated pygame.time.get_ticks() calls inside hot loops; updated Pickaxe.update(current_time=...) accordingly.
- Reworked chunk cleanup to remove each block’s body/shape from the Pymunk Space before deleting chunk data, preventing physics-object buildup over time; delete_block optionally removes from Space as well.
- Optimized TNT/MegaTNT damage application to iterate only chunks intersecting the blast radius (instead of scanning all blocks in all chunks), and reused a shared font + blink overlay surface to reduce per-frame allocations.
- Cached destroy-stage overlay textures per atlas and reused them in Block.draw to avoid repeated subsurface calls.
- Cached HUD icon surfaces and outlined text surfaces; only re-render amounts/indicators when values change.
- Fixed explosion animation timing to use per-frame delta (dt_ms) and pre-rotated particle frames once per particle to avoid repeated rotations each frame.
- Batched YouTube chat log writes (one append per poll) instead of opening/writing the file per message.
- Reduced scaling cost by using pygame.transform.scale into a reusable surface rather than smoothscale allocations every frame.