### PR TITLE
fix: render the TNT blink with per-pixel alpha so it is not a solid white square

### DIFF
--- a/src/tnt.py
+++ b/src/tnt.py
@@ -55,6 +55,10 @@ class Tnt:
             Tnt._font = pygame.font.Font(None, 70)
         self.font = Tnt._font
 
+        # The blink alpha must live in the pixels rather than come from set_alpha(). main.py's
+        # internal_surface inherits the display format, which on macOS carries an alpha channel
+        # that sprite blits leave at 0; a set_alpha() overlay then composites against a
+        # transparent destination and renders solid white. draw() refills this each frame.
         self._overlay_surface = pygame.Surface(self.texture.get_size(), pygame.SRCALPHA)
         self._overlay_surface.fill((255, 255, 255))
 
@@ -133,7 +137,7 @@ class Tnt:
         brightness = (math.sin(current_time / blink_period * 2 * math.pi) + 1) / 2  # range 0-1
         alpha = int(brightness * 192)  # maximum 75% opacity
 
-        self._overlay_surface.set_alpha(alpha)
+        self._overlay_surface.fill((255, 255, 255, alpha))
         rotated_overlay = pygame.transform.rotate(self._overlay_surface, -math.degrees(self.body.angle))
         overlay_rect = rotated_overlay.get_rect(center=(self.body.position.x, self.body.position.y))
         overlay_rect.y -= camera.offset_y
@@ -201,7 +205,7 @@ class MegaTnt(Tnt):
         brightness = (math.sin(current_time / blink_period * 2 * math.pi) + 1) / 2
         alpha = int(brightness * 192)
 
-        self._overlay_surface.set_alpha(alpha)
+        self._overlay_surface.fill((255, 255, 255, alpha))
         rotated_overlay = pygame.transform.rotate(self._overlay_surface, -math.degrees(self.body.angle))
         overlay_rect = rotated_overlay.get_rect(center=(self.body.position.x, self.body.position.y))
         overlay_rect.y -= camera.offset_y


### PR DESCRIPTION
On macOS Catalina (python 3.9) the TNT block rendered as a plain white square while every other sprite drew correctly. MegaTNT was affected in the same way.

`main.py` builds its render target as `pygame.Surface((w, h))` with no depth argument, which inherits the display format. The SDL cocoa window is `ARGB8888`, so `internal_surface` carries an alpha channel the game never maintains. Opaque sprite blits take pygame's opaque-destination fast path, which writes RGB but leaves that alpha at 0, so a freshly drawn block reads back as (143, 143, 143, 0).

TNT is the only sprite that then blends something translucent over pixels already drawn: the pulsing white overlay in `Tnt.draw`. Because `set_alpha()` makes pygame composite against the destination's alpha, and that alpha is 0, the destination contributes nothing and the white wins outright. The whole 120px block came out (255, 255, 255) at every phase of the blink. Other sprites were unaffected because a straight copy of an opaque texture is indistinguishable from a correct blend, which is why only TNT showed it. Windows and Linux typically give `XRGB8888` with no alpha channel, so this does not reproduce there.

Filling the overlay as (255, 255, 255, alpha) puts the alpha in the pixels, which takes pygame's opaque-destination blend path and ignores destination alpha, so the result is correct regardless of the display format.

Giving `internal_surface` an explicit depth of 24 also fixes the blend, but `transform.scale` with a destination surface requires both surfaces to share a format, and scaled_surface follows the display via .convert():

```
    ValueError: Source and destination surfaces need the same format.
```

Matching them would mean changing `scaled_surface` in two more places and would leave the per-frame blit to screen doing a converting copy, so the fix is kept local to the overlay and the render pipeline is untouched.

Verified on macOS with pygame 2.6.1 / SDL 2.28.4, driving the real Tnt and MegaTnt through `main.py`'s surface pipeline: across a full blink cycle the TNT centre pixel tracks the pulse from (205, 204, 213) at peak down to (55, 54, 86) at the trough, which is exactly the unmodified texture colour.